### PR TITLE
Fixed blank reading after error

### DIFF
--- a/examples/prometheus/main.go
+++ b/examples/prometheus/main.go
@@ -102,6 +102,7 @@ func listen(conn *net.UDPConn, counter prometheus.Counter, powerGauge, batteryGa
 		elec, err := owl.Read(buf[:n])
 		if err != nil {
 			fmt.Println(err)
+			continue
 		}
 
 		counter.Inc()


### PR DESCRIPTION
There was a continue missing in the for loop. With the continue in place the blank reading should be skipped as desired.